### PR TITLE
add missing rpush mocks #24

### DIFF
--- a/src/main/java/com/fiftyonred/mock_jedis/DataContainer.java
+++ b/src/main/java/com/fiftyonred/mock_jedis/DataContainer.java
@@ -1,9 +1,12 @@
 package com.fiftyonred.mock_jedis;
 
-import redis.clients.jedis.Protocol;
-
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import redis.clients.jedis.Protocol;
 
 /**
  * Container for redis data (key/value bytes).
@@ -125,8 +128,12 @@ public class DataContainer implements Comparable<DataContainer> {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (!(o instanceof DataContainer)) return false;
+		if (this == o) {
+            return true;
+        }
+		if (!(o instanceof DataContainer)) {
+            return false;
+        }
 
 		DataContainer that = (DataContainer) o;
 
@@ -165,7 +172,6 @@ public class DataContainer implements Comparable<DataContainer> {
 		return string;
 	}
 
-	@Override
 	public int compareTo(DataContainer o) {
 		// compare string representation of data (in the same way as redis does)
 		return string.compareTo(o.getString());

--- a/src/main/java/com/fiftyonred/mock_jedis/MockJedis.java
+++ b/src/main/java/com/fiftyonred/mock_jedis/MockJedis.java
@@ -1,12 +1,12 @@
 package com.fiftyonred.mock_jedis;
 
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Pipeline;
-import redis.clients.jedis.SortingParams;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.SortingParams;
 
 public class MockJedis extends Jedis {
 
@@ -780,5 +780,25 @@ public class MockJedis extends Jedis {
 	@Override
 	public String quit() {
 		return "OK";
+	}
+
+	@Override
+	public Long rpush(byte[] key, byte[]... strings) {
+	    return 0l;
+	}
+
+	@Override
+	public Long rpush(String key, String... strings) {
+	    return 0l;
+	}
+
+	@Override
+	public Long rpushx(byte[] key, byte[]... string) {
+	    return 0l;
+	}
+
+	@Override
+	public Long rpushx(String key, String... string) {
+	    return 0l;
 	}
 }

--- a/src/main/java/com/fiftyonred/mock_jedis/MockPipeline.java
+++ b/src/main/java/com/fiftyonred/mock_jedis/MockPipeline.java
@@ -1,12 +1,26 @@
 package com.fiftyonred.mock_jedis;
 
-import com.fiftyonred.utils.WildcardMatcher;
-import redis.clients.jedis.*;
+import static com.fiftyonred.mock_jedis.DataContainer.CHARSET;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import redis.clients.jedis.BuilderFactory;
+import redis.clients.jedis.Pipeline;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Response;
+import redis.clients.jedis.SortingParams;
 import redis.clients.jedis.exceptions.JedisDataException;
 
-import java.util.*;
-
-import static com.fiftyonred.mock_jedis.DataContainer.CHARSET;
+import com.fiftyonred.utils.WildcardMatcher;
 
 public class MockPipeline extends Pipeline {
 
@@ -739,14 +753,12 @@ public class MockPipeline extends Pipeline {
 		final int direction = params.contains(Protocol.Keyword.DESC.name().toLowerCase()) ? -1 : 1;
 		if (params.contains(Protocol.Keyword.ALPHA.name().toLowerCase())) {
 			comparator = new Comparator<DataContainer>() {
-				@Override
 				public int compare(final DataContainer o1, final DataContainer o2) {
 					return o1.compareTo(o2) * direction;
 				}
 			};
 		} else {
 			comparator = new Comparator<DataContainer>() {
-				@Override
 				public int compare(final DataContainer o1, final DataContainer o2) {
 					final Long i1, i2;
 					try {

--- a/src/test/java/com/fiftyonred/mock_jedis/MockJedisThreadSafeTest.java
+++ b/src/test/java/com/fiftyonred/mock_jedis/MockJedisThreadSafeTest.java
@@ -1,10 +1,11 @@
 package com.fiftyonred.mock_jedis;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
 
-import static org.junit.Assert.assertEquals;
+import redis.clients.jedis.Jedis;
 
 public class MockJedisThreadSafeTest {
 	private Jedis j = null;
@@ -17,7 +18,6 @@ public class MockJedisThreadSafeTest {
 	@Test
 	public void testThreadSafety() throws InterruptedException {
 		final Thread t1 = new Thread(new Runnable() {
-			@Override
 			public void run() {
 				for (int i = 0; i < 1000; ++i) {
 					j.incr("test");
@@ -25,7 +25,6 @@ public class MockJedisThreadSafeTest {
 			}
 		});
 		final Thread t2 = new Thread(new Runnable() {
-			@Override
 			public void run() {
 				for (int i = 0; i < 1000; ++i) {
 					j.decr("test");


### PR DESCRIPTION
Quick fix for #24. The mock methods simply return 0 and don't do anything. 

Also removes some @Overrides that are errors according to eclipse. They are only needed when you actually override implementation; not for implementing interfaces.