### PR TITLE
Fixed Integer calculation overflow when use high TTL in seconds

### DIFF
--- a/src/main/java/com/fiftyonred/mock_jedis/MockPipeline.java
+++ b/src/main/java/com/fiftyonred/mock_jedis/MockPipeline.java
@@ -288,16 +288,20 @@ public class MockPipeline extends Pipeline {
 
 	@Override
 	public Response<String> setex(final String key, final int seconds, final String value) {
-		return psetex(key, seconds * 1000, value);
+		return psetex(key, (long)seconds * 1000, value);
 	}
 
 	@Override
 	public Response<String> setex(final byte[] key, final int seconds, final byte[] value) {
-		return psetex(key, seconds * 1000, value);
+		return psetex(key, (long)seconds * 1000, value);
 	}
 
 	@Override
 	public Response<String> psetex(final String key, final int milliseconds, final String value) {
+		return psetex(key, (long)milliseconds, value);
+	}
+
+	public Response<String> psetex(final String key, final long milliseconds, final String value) {
 		mockStorage.psetex(DataContainer.from(key), milliseconds, DataContainer.from(value));
 		final Response<String> response = new Response<String>(BuilderFactory.STRING);
 		response.set(OK_RESPONSE);
@@ -306,6 +310,10 @@ public class MockPipeline extends Pipeline {
 
 	@Override
 	public Response<String> psetex(final byte[] key, final int milliseconds, final byte[] value) {
+		return psetex(key, (long)milliseconds, value);
+	}
+
+	public Response<String> psetex(final byte[] key, final long milliseconds, final byte[] value) {
 		mockStorage.psetex(DataContainer.from(key), milliseconds, DataContainer.from(value));
 		final Response<String> response = new Response<String>(BuilderFactory.STRING);
 		response.set(OK_RESPONSE);

--- a/src/main/java/com/fiftyonred/mock_jedis/MockStorage.java
+++ b/src/main/java/com/fiftyonred/mock_jedis/MockStorage.java
@@ -203,6 +203,10 @@ public class MockStorage {
 	}
 
 	public synchronized void psetex(final DataContainer key, final int milliseconds, final DataContainer value) {
+		psetex(key, (long)milliseconds, value);
+	}
+
+	public synchronized void psetex(final DataContainer key, final long milliseconds, final DataContainer value) {
 		set(key, value);
 		pexpireAt(key, System.currentTimeMillis() + milliseconds);
 	}

--- a/src/test/java/com/fiftyonred/mock_jedis/MockJedisExpireTest.java
+++ b/src/test/java/com/fiftyonred/mock_jedis/MockJedisExpireTest.java
@@ -43,6 +43,17 @@ public class MockJedisExpireTest {
 	}
 
 	@Test
+	public void testSetexWithHighTtl() throws InterruptedException {
+		int delay = 7776000; //90 days in seconds
+
+		j.setex("test", delay, "value");
+
+		assertTrue(j.ttl("test") > 0);
+		assertNotNull(j.get("test"));
+		assertEquals("value",j.get("test"));
+	}
+
+	@Test
 	public void testExpire() throws InterruptedException {
 		int delay = 1;
 


### PR DESCRIPTION
Fixed Integer calculation overflow when use high TTL in seconds (like 90 days in seconds) when converting to milliseconds using int

This causes the setex method to set a value with a expired TTL, invalidating the key.

This test case bellow self-explains what is expected and now fixed:

```
    @Test
    public void testSetexWithHighTtl() throws InterruptedException {
        int delay = 7776000; //90 days in seconds

        j.setex("test", delay, "value");

        assertTrue(j.ttl("test") > 0);
        assertNotNull(j.get("test"));
        assertEquals("value",j.get("test"));
    }
```
